### PR TITLE
Require user context for section and evaluation APIs

### DIFF
--- a/ctp-docente-portal.Server/Controllers/EvaluationItemsController.cs
+++ b/ctp-docente-portal.Server/Controllers/EvaluationItemsController.cs
@@ -3,6 +3,7 @@ using ctp_docente_portal.Server.Services.Interfaces;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
 
 namespace ctp_docente_portal.Server.Controllers
 {
@@ -62,7 +63,8 @@ namespace ctp_docente_portal.Server.Controllers
         [HttpGet("subject/{subjectId}/section/{sectionId}")]
         public async Task<IActionResult> GetBySectionAssignment(int subjectId, int sectionId)
         {
-            var result = await _service.GetItemsBySubjectAndSectionAsync(subjectId, sectionId);
+            var userId = int.Parse(User.FindFirst(ClaimTypes.NameIdentifier)?.Value);
+            var result = await _service.GetItemsBySubjectAndSectionAsync(subjectId, sectionId, userId);
             return Ok(result);
         }
 
@@ -70,7 +72,8 @@ namespace ctp_docente_portal.Server.Controllers
         [HttpGet("item/{itemId}")]
         public async Task<IActionResult> GetItemDetails(int itemId)
         {
-            var result = await _service.GetDetailsByIdAsync(itemId);
+            var userId = int.Parse(User.FindFirst(ClaimTypes.NameIdentifier)?.Value);
+            var result = await _service.GetDetailsByIdAsync(itemId, userId);
             return Ok(result);
         }
 

--- a/ctp-docente-portal.Server/Controllers/EvaluationScoresController.cs
+++ b/ctp-docente-portal.Server/Controllers/EvaluationScoresController.cs
@@ -5,6 +5,7 @@ using ctp_docente_portal.Server.Services.Interfaces;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
 
 namespace ctp_docente_portal.Server.Controllers
 {
@@ -25,8 +26,9 @@ namespace ctp_docente_portal.Server.Controllers
         [HttpGet("subject/{subjectId}/section/{sectionId}")]
         public async Task<IActionResult> GetEvaluationMatrixBySection(int subjectId, int sectionId)
         {
-            var matrix = await _evaluationScoreService.GetStudentScoresMatrixAsync(subjectId, sectionId);
-            var items = await _evaluationItemService.GetItemsBySubjectAndSectionAsync(subjectId, sectionId);
+            var userId = int.Parse(User.FindFirst(ClaimTypes.NameIdentifier)?.Value);
+            var matrix = await _evaluationScoreService.GetStudentScoresMatrixAsync(subjectId, sectionId, userId);
+            var items = await _evaluationItemService.GetItemsBySubjectAndSectionAsync(subjectId, sectionId, userId);
 
             var response = new EvaluationMatrixResponseDto
             {

--- a/ctp-docente-portal.Server/Controllers/SectionAssignmentsController.cs
+++ b/ctp-docente-portal.Server/Controllers/SectionAssignmentsController.cs
@@ -20,6 +20,17 @@ namespace ctp_docente_portal.Server.Controllers
             _sectionAssignmentsService = sectionAssignmentsService;
         }
 
+        [HttpGet("getassignmentid")]
+        public async Task<IActionResult> GetAssignmentId([FromQuery] int subjectId, [FromQuery] int sectionId)
+        {
+            var assignmentId = await _sectionAssignmentsService.GetSectionAssignmentIdAsync(subjectId, sectionId);
+
+            if (assignmentId == null)
+                return NotFound("No se encontró un SectionAssignment con esos parámetros.");
+
+            return Ok(assignmentId);
+        }
+
         [HttpGet]
         [Authorize(Policy = "AdministrativoOnly")]
         public async Task<ActionResult<PagedResult<SectionAssignmentDto>>> GetAllAsync([FromQuery] PaginationParams paginationParams)

--- a/ctp-docente-portal.Server/Controllers/SectionController.cs
+++ b/ctp-docente-portal.Server/Controllers/SectionController.cs
@@ -5,6 +5,7 @@ using ctp_docente_portal.Server.Services.Interfaces;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
 
 namespace ctp_docente_portal.Server.Controllers
 {
@@ -33,7 +34,8 @@ namespace ctp_docente_portal.Server.Controllers
         [Authorize(Policy = "DocenteOnly")]
         public async Task<ActionResult<List<SectionDto>>> GetSections(int academicPeriodId, int subjectId)
         {
-            var sections = await _sectionService.GetSectionsByPeriodAndSubjectAsync(academicPeriodId, subjectId);
+            var userId = int.Parse(User.FindFirst(ClaimTypes.NameIdentifier)?.Value);
+            var sections = await _sectionService.GetSectionsByPeriodAndSubjectAsync(academicPeriodId, subjectId, userId);
             return Ok(sections);
         }
 

--- a/ctp-docente-portal.Server/Controllers/StudentsController.cs
+++ b/ctp-docente-portal.Server/Controllers/StudentsController.cs
@@ -4,6 +4,7 @@ using ctp_docente_portal.Server.Services.Interfaces;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
 
 namespace ctp_docente_portal.Server.Controllers
 {
@@ -23,7 +24,8 @@ namespace ctp_docente_portal.Server.Controllers
         [HttpGet("section/{sectionId}")]
         public async Task<ActionResult<List<StudentDto>>> GetSectionStudents(int sectionId)
         {
-            var students = await _studentService.GetStudentsBySectionAsync(sectionId);
+            var userId = int.Parse(User.FindFirst(ClaimTypes.NameIdentifier)?.Value);
+            var students = await _studentService.GetStudentsBySectionAsync(sectionId, userId);
             return Ok(students);
         }
     }

--- a/ctp-docente-portal.Server/DTOs/EvaluationItems/EvaluationItemCreateDto.cs
+++ b/ctp-docente-portal.Server/DTOs/EvaluationItems/EvaluationItemCreateDto.cs
@@ -4,6 +4,7 @@ namespace ctp_docente_portal.Server.DTOs.EvaluationItems
 {
     public class EvaluationItemCreateDto
     {
+        public int Id { get; set; }
         public int SectionAssignmentId { get; set; }
         public string Name { get; set; }
         public string Description { get; set; }

--- a/ctp-docente-portal.Server/Services/Implementations/EvaluationScoreService.cs
+++ b/ctp-docente-portal.Server/Services/Implementations/EvaluationScoreService.cs
@@ -27,10 +27,10 @@ namespace ctp_docente_portal.Server.Services.Implementations
             _mapper = mapper;
         }
 
-        public async Task<List<StudentEvaluationMatrixDto>> GetStudentScoresMatrixAsync(int subjectId, int sectionId)
+        public async Task<List<StudentEvaluationMatrixDto>> GetStudentScoresMatrixAsync(int subjectId, int sectionId, int userId)
         {
-            var studentDtos = await _studentService.GetStudentsBySectionAsync(sectionId);
-            var itemDtos = await _evaluationService.GetItemsBySubjectAndSectionAsync(subjectId, sectionId);
+            var studentDtos = await _studentService.GetStudentsBySectionAsync(sectionId, userId);
+            var itemDtos = await _evaluationService.GetItemsBySubjectAndSectionAsync(subjectId, sectionId, userId);
 
             var itemIds = itemDtos.Select(i => i.Id).ToList();
             var studentIds = studentDtos.Select(s => s.Id).ToList();

--- a/ctp-docente-portal.Server/Services/Implementations/SectionAssignmentsService.cs
+++ b/ctp-docente-portal.Server/Services/Implementations/SectionAssignmentsService.cs
@@ -17,6 +17,15 @@ namespace ctp_docente_portal.Server.Services.Implementations
             _context = context;
         }
 
+        public async Task<int?> GetSectionAssignmentIdAsync(int subjectId, int sectionId)
+        {
+            var assignment = await _context.SectionAssignments
+                .Where(sa => sa.SubjectId == subjectId && sa.SectionId == sectionId)
+                .FirstOrDefaultAsync();
+
+            return assignment?.Id;
+        }
+
         public async Task<PagedResult<SectionAssignmentDto>> GetAllAsync(PaginationParams paginationParams)
         {
             var query =

--- a/ctp-docente-portal.Server/Services/Implementations/SectionService.cs
+++ b/ctp-docente-portal.Server/Services/Implementations/SectionService.cs
@@ -37,10 +37,16 @@ namespace ctp_docente_portal.Server.Services.Implementations
             return _mapper.Map<SectionDto>(section);
         }
 
-        public async Task<List<SectionDto>> GetSectionsByPeriodAndSubjectAsync(int academicPeriodId, int subjectId)
+        public async Task<List<SectionDto>> GetSectionsByPeriodAndSubjectAsync(int academicPeriodId, int subjectId, int userId)
         {
-            // TODO: El "staffId" debo obtenerlo del usuarios cuando esté listo la autenticación
-            int staffId = 53;
+            int staffId = await _context.StaffUserLinks
+                .Where(x => x.UserId == userId)
+                .Select(x => x.StaffId)
+                .FirstOrDefaultAsync();
+            if (staffId == 0)
+            {
+                throw new KeyNotFoundException($"Usuario con ID {userId} no encontrado");
+            }
 
             if (academicPeriodId <= 0 || subjectId <= 0)
             {

--- a/ctp-docente-portal.Server/Services/Implementations/StudentService.cs
+++ b/ctp-docente-portal.Server/Services/Implementations/StudentService.cs
@@ -18,9 +18,17 @@ namespace ctp_docente_portal.Server.Services.Implementations
             _mapper = mapper;
         }
 
-        public async Task<List<StudentDto>> GetStudentsBySectionAsync(int sectionId)
+        public async Task<List<StudentDto>> GetStudentsBySectionAsync(int sectionId, int userId)
         {
-            int staffId = 53;
+            int staffId = await _context.StaffUserLinks
+                .Where(x => x.UserId == userId)
+                .Select(x => x.StaffId)
+                .FirstOrDefaultAsync();
+
+            if (staffId == 0)
+            {
+                throw new KeyNotFoundException($"Usuario con ID {userId} no encontrado");
+            }
 
             // Validación de asignación de sección
             bool isAssigned = await _context.SectionAssignments

--- a/ctp-docente-portal.Server/Services/Interfaces/IEvaluationItemService.cs
+++ b/ctp-docente-portal.Server/Services/Interfaces/IEvaluationItemService.cs
@@ -8,8 +8,8 @@ namespace ctp_docente_portal.Server.Services.Interfaces
         Task<EvaluationItemDto> UpdateAsync(int id, EvaluationItemUpdateDto dto);
         Task DeleteAsync(int id);
         Task<EvaluationItemDto> GetByIdAsync(int id);
-        Task<EvaluationItemDetailsDto> GetDetailsByIdAsync(int id, int? studentId = null);
-        Task<List<EvaluationItemDto>> GetItemsBySubjectAndSectionAsync(int subjectId, int sectionId);
+        Task<EvaluationItemDetailsDto> GetDetailsByIdAsync(int id, int userId, int? studentId = null);
+        Task<List<EvaluationItemDto>> GetItemsBySubjectAndSectionAsync(int subjectId, int sectionId, int userId);
         Task<int> CreateDraftEvaluationItemAsync(EvaluationItemDraftCreateDto dto);
     }
 }

--- a/ctp-docente-portal.Server/Services/Interfaces/IEvaluationScoreService.cs
+++ b/ctp-docente-portal.Server/Services/Interfaces/IEvaluationScoreService.cs
@@ -5,7 +5,7 @@ namespace ctp_docente_portal.Server.Services.Interfaces
 {
     public interface IEvaluationScoreService
     {
-        Task<List<StudentEvaluationMatrixDto>> GetStudentScoresMatrixAsync(int subjectId, int sectionId);
+        Task<List<StudentEvaluationMatrixDto>> GetStudentScoresMatrixAsync(int subjectId, int sectionId, int userId);
         Task UpsertStudentScoresAsync(int sectionId, List<StudentEvaluationScoreDto> scores);
     }
 }

--- a/ctp-docente-portal.Server/Services/Interfaces/ISectionAssignmentsService.cs
+++ b/ctp-docente-portal.Server/Services/Interfaces/ISectionAssignmentsService.cs
@@ -7,6 +7,7 @@ namespace ctp_docente_portal.Server.Services.Interfaces
     public interface ISectionAssignmentsService
     {
         Task<PagedResult<SectionAssignmentDto>> GetAllAsync(PaginationParams paginationParams);
+        Task<int?> GetSectionAssignmentIdAsync(int subjectId, int sectionId);
         Task<SectionAssignmentsModel> CreateAsync(SectionAssignmentCreateDto dto, int userId);
         Task<SectionAssignmentsModel> UpdateAsync(SectionAssignmentUpdateDto dto, int userId);
         Task<bool> DeleteAsync(int id);

--- a/ctp-docente-portal.Server/Services/Interfaces/ISectionService.cs
+++ b/ctp-docente-portal.Server/Services/Interfaces/ISectionService.cs
@@ -6,7 +6,7 @@ namespace ctp_docente_portal.Server.Services.Interfaces
     public interface ISectionService
     {
         Task<List<SectionDto>> GetAllAsync();
-        Task<List<SectionDto>> GetSectionsByPeriodAndSubjectAsync(int academicPeriodId, int subjectId);
+        Task<List<SectionDto>> GetSectionsByPeriodAndSubjectAsync(int academicPeriodId, int subjectId, int userId);
         Task<SectionDto> GetByIdAsync(int id);
 
         Task<List<SectionOptionDto>> GetOptionsAsync(int? year = null, int? enrollmentId = null, bool? isActive = null, int? gradeId = null, CancellationToken ct = default);

--- a/ctp-docente-portal.Server/Services/Interfaces/IStudentService.cs
+++ b/ctp-docente-portal.Server/Services/Interfaces/IStudentService.cs
@@ -4,6 +4,6 @@ namespace ctp_docente_portal.Server.Services.Interfaces
 {
     public interface IStudentService
     {
-        Task<List<StudentDto>> GetStudentsBySectionAsync(int sectionId);
+        Task<List<StudentDto>> GetStudentsBySectionAsync(int sectionId, int userId);
     }
 }

--- a/ctp-docente-portal.client/src/App.jsx
+++ b/ctp-docente-portal.client/src/App.jsx
@@ -111,10 +111,10 @@ function App() {
               path: "notificaciones",
               element: <Notificaciones />,
             },
-            {
-              path: "estudiantes",
-              element: <Estudiantes />,
-            },
+            // {
+            //   path: "estudiantes",
+            //   element: <Estudiantes />,
+            // },
           ],
         },
       ],
@@ -129,7 +129,7 @@ function App() {
 
   return (
     <>
-      <Suspense fallback={null}>
+      <Suspense fallback={<Loader1 />}>
         <RouterProvider router={router} />
         <Toaster
           toastOptions={{

--- a/ctp-docente-portal.client/src/components/Sidebar.jsx
+++ b/ctp-docente-portal.client/src/components/Sidebar.jsx
@@ -123,13 +123,13 @@ export default function Sidebar({ isMobileOpen, onCloseMobile }) {
             active={location.pathname.includes("/notificaciones")}
             collapsed={collapsed}
           />
-          <NavItem
+          {/* <NavItem
             href="/estudiantes"
             icon={<Users className="h-5 w-5" />}
             label="Estudiantes"
             active={location.pathname.includes("/estudiantes")}
             collapsed={collapsed}
-          />
+          /> */}
         </aside>
       </div>
 

--- a/ctp-docente-portal.client/src/components/adminSettings/AcademicPeriods.jsx
+++ b/ctp-docente-portal.client/src/components/adminSettings/AcademicPeriods.jsx
@@ -75,7 +75,7 @@ const AcademicPeriods = () => {
     const fetchData = async () => {
       try {
         setLoading(true);
-        const token = localStorage.getItem("token");
+        const token = sessionStorage.getItem("token");
         const response = await axios.get("api/enrollment", {
           headers: { Authorization: `Bearer ${token}` },
         });
@@ -93,7 +93,7 @@ const AcademicPeriods = () => {
     const fetchData = async () => {
       try {
         setLoading(true);
-        const token = localStorage.getItem("token");
+        const token = sessionStorage.getItem("token");
         const { data } = await axios.get(
           `api/academicperiods/pagination?pageNumber=${pagination.pageNumber}&pageSize=${pagination.pageSize}`,
           {
@@ -185,7 +185,7 @@ const AcademicPeriods = () => {
     try {
       if (periodId > 0) {
         setLoading(true);
-        const token = localStorage.getItem("token");
+        const token = sessionStorage.getItem("token");
         const response = await axios.delete(`api/academicperiods/${periodId}`, {
           headers: { Authorization: `Bearer ${token}` },
         });
@@ -215,7 +215,7 @@ const AcademicPeriods = () => {
   const handleSave = async () => {
     try {
       setLoading(true);
-      const token = localStorage.getItem("token");
+      const token = sessionStorage.getItem("token");
       if (validateForm()) {
         const year = new Date(periodForm.startDate).getFullYear();
         const dataToSend = {

--- a/ctp-docente-portal.client/src/components/adminSettings/EvaluationRoles.jsx
+++ b/ctp-docente-portal.client/src/components/adminSettings/EvaluationRoles.jsx
@@ -79,7 +79,7 @@ const EvaluationRoles = () => {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const token = localStorage.getItem("token");
+        const token = sessionStorage.getItem("token");
         setLoading(true);
         const [usersResponse, evaluationRolesResponse, staffResponse] =
           await Promise.all([
@@ -111,7 +111,7 @@ const EvaluationRoles = () => {
     const fetchData = async () => {
       try {
         setLoading(true);
-        const token = localStorage.getItem("token");
+        const token = sessionStorage.getItem("token");
         const { data } = await axios.get(
           `api/evaluationstaffroles/pagination?pageNumber=${pagination.pageNumber}&pageSize=${pagination.pageSize}`,
           {
@@ -187,7 +187,7 @@ const EvaluationRoles = () => {
   const deleteAssignment = async () => {
     try {
       setLoading(true);
-      const token = localStorage.getItem("token");
+      const token = sessionStorage.getItem("token");
       const response = await axios.delete(
         `api/evaluationstaffroles/${staffRoleId}`,
         {
@@ -238,7 +238,7 @@ const EvaluationRoles = () => {
   const handleSave = async () => {
     try {
       if (validateStaffRoleForm()) {
-        const token = localStorage.getItem("token");
+        const token = sessionStorage.getItem("token");
         setLoading(true);
         if (staffRoleForm.id) {
           const response = await axios.put(
@@ -284,7 +284,7 @@ const EvaluationRoles = () => {
   const handleSaveLink = async () => {
     try {
       if (validateStaffUserForm()) {
-        const token = localStorage.getItem("token");
+        const token = sessionStorage.getItem("token");
         setLoading(true);
         const response = await axios.post(
           "api/staffuserlinks",

--- a/ctp-docente-portal.client/src/components/adminSettings/SectionAssignments.jsx
+++ b/ctp-docente-portal.client/src/components/adminSettings/SectionAssignments.jsx
@@ -82,7 +82,7 @@ const SectionAssignments = () => {
     const fetchData = async () => {
       try {
         setLoading(true);
-        const token = localStorage.getItem("token");
+        const token = sessionStorage.getItem("token");
         const [subjects, staff, academicPeriods, sections] = await Promise.all([
           axios.get("api/subject", {
             headers: { Authorization: `Bearer ${token}` },
@@ -117,7 +117,7 @@ const SectionAssignments = () => {
     const fetchAssignments = async () => {
       try {
         setLoading(true);
-        const token = localStorage.getItem("token");
+        const token = sessionStorage.getItem("token");
         const { data } = await axios.get(
           `api/sectionassignments?pageNumber=${pagination.pageNumber}&pageSize=${pagination.pageSize}`,
           { headers: { Authorization: `Bearer ${token}` } }
@@ -203,7 +203,7 @@ const SectionAssignments = () => {
     try {
       if (assignmentId > 0) {
         setLoading(true);
-        const token = localStorage.getItem("token");
+        const token = sessionStorage.getItem("token");
         const response = await axios.delete(
           `api/sectionassignments/${assignmentId}`,
           {
@@ -254,7 +254,7 @@ const SectionAssignments = () => {
   const handleSave = async () => {
     try {
       if (validateForm()) {
-        const token = localStorage.getItem("token");
+        const token = sessionStorage.getItem("token");
         if (assignmentForm.id) {
           const response = await axios.put(
             `api/sectionassignments/${assignmentForm.id}`,

--- a/ctp-docente-portal.client/src/components/adminSettings/Subjects.jsx
+++ b/ctp-docente-portal.client/src/components/adminSettings/Subjects.jsx
@@ -60,7 +60,7 @@ const Subjects = () => {
     const fetchData = async () => {
       try {
         setLoading(true);
-        const token = localStorage.getItem("token");
+        const token = sessionStorage.getItem("token");
         const { data } = await axios.get(
           `api/subject/pagination?pageNumber=${pagination.pageNumber}&pageSize=${pagination.pageSize}`,
           {
@@ -118,7 +118,7 @@ const Subjects = () => {
     try {
       if (subjectId > 0) {
         setLoading(true);
-        const token = localStorage.getItem("token");
+        const token = sessionStorage.getItem("token");
         const response = await axios.delete(`api/subject/${subjectId}`, {
           headers: { Authorization: `Bearer ${token}` },
         });
@@ -155,7 +155,7 @@ const Subjects = () => {
     try {
       if (validateForm()) {
         setLoading(true);
-        const token = localStorage.getItem("token");
+        const token = sessionStorage.getItem("token");
         if (subjectForm.id) {
           const response = await axios.put(
             `api/subject/${subjectForm.id}`,

--- a/ctp-docente-portal.client/src/components/evaluations/EvaluationItems.jsx
+++ b/ctp-docente-portal.client/src/components/evaluations/EvaluationItems.jsx
@@ -17,7 +17,10 @@ const EvaluationItems = () => {
   const deleteItem = async (id) => {
     try {
       setLoading(true);
-      await axios.delete(`/api/evaluationitems/${id}`);
+      const token = sessionStorage.getItem("token");
+      await axios.delete(`/api/evaluationitems/${id}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
       toast.success("Item eliminado correctamente.");
 
       const updateItems = [...evaluationItems].filter((ei) => ei.id !== id);

--- a/ctp-docente-portal.client/src/components/evaluations/GradingInterface.jsx
+++ b/ctp-docente-portal.client/src/components/evaluations/GradingInterface.jsx
@@ -87,9 +87,13 @@ const GradingInterface = () => {
         }))
       );
 
+      const token = sessionStorage.getItem("token");
       const response = await axios.post(
         `/api/evaluationscores/section/${selectedGroup}`,
-        payload
+        payload,
+        {
+          headers: { Authorization: `Bearer ${token}` },
+        }
       );
       console.log(response.data);
       toast.success("Cambios guardados correctamente.");
@@ -137,7 +141,7 @@ const GradingInterface = () => {
       </Card>
 
       {/* Save Status */}
-      <Alert
+      {/* <Alert
         className={`mt-4 ${saveStatus === "idle" && "opacity-0"}
             ${
               saveStatus === "error"
@@ -154,20 +158,20 @@ const GradingInterface = () => {
           {saveStatus === "error" && "Error al guardar los cambios"}
           {saveStatus === "idle" && "Hola Mundo"}
         </AlertDescription>
-      </Alert>
+      </Alert> */}
 
       {/* Grading Table */}
-      <Card className="mt-4">
-        <CardHeader>
+      <Card className="mt-4 max-h-[600px] overflow-y-auto [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]">
+        <CardHeader className="sticky top-0 bg-background-dark/80 z-10">
           <CardTitle className="flex flex-col sm:flex-row items-start sm:items-center justify-between">
             <span className="mx-auto sm:mx-0 mb-4 sm:mb-0">
               Estudiantes ({filteredStudents.length})
             </span>
             <div className="flex gap-4 flex-col sm:flex-row">
-              <Button size="sm" variant="outline">
+              {/* <Button size="sm" variant="outline">
                 <Download className="w-4 h-4 mr-2" />
                 Descargar Reporte
-              </Button>
+              </Button> */}
 
               <Button
                 size="sm"
@@ -190,7 +194,7 @@ const GradingInterface = () => {
             </div>
           </CardTitle>
         </CardHeader>
-        <CardContent>
+        <CardContent className="mt-4">
           <GradeTable
             students={filteredStudents}
             criteria={evaluationItems}

--- a/ctp-docente-portal.client/src/context/AuthProvider.jsx
+++ b/ctp-docente-portal.client/src/context/AuthProvider.jsx
@@ -10,8 +10,8 @@ export const AuthProvider = ({ children }) => {
 
   useEffect(() => {
     const fetchUser = async () => {
-      const token = localStorage.getItem("token");
-      const userId = localStorage.getItem("userId");
+      const token = sessionStorage.getItem("token");
+      const userId = sessionStorage.getItem("userId");
       // const username = localStorage.getItem("username");
 
       if (token && userId) {
@@ -37,8 +37,8 @@ export const AuthProvider = ({ children }) => {
             }
           }
           toast.error(Message);
-          localStorage.removeItem("token");
-          localStorage.removeItem("userId");
+          sessionStorage.removeItem("token");
+          sessionStorage.removeItem("userId");
         }
       }
       setLoading(false);
@@ -53,8 +53,8 @@ export const AuthProvider = ({ children }) => {
 
       const { token, user } = response.data;
 
-      localStorage.setItem("token", token);
-      localStorage.setItem("userId", user.id);
+      sessionStorage.setItem("token", token);
+      sessionStorage.setItem("userId", user.id);
 
       setUser(user);
       setRoles(user.roles);
@@ -67,8 +67,8 @@ export const AuthProvider = ({ children }) => {
 
   const logout = async () => {
     setLoading(true);
-    localStorage.removeItem("token");
-    localStorage.removeItem("username");
+    sessionStorage.removeItem("token");
+    sessionStorage.removeItem("username");
     sessionStorage.removeItem("selectedPeriod");
     sessionStorage.removeItem("selectedSubject");
     sessionStorage.removeItem("selectedGroup");

--- a/ctp-docente-portal.client/src/context/useEvaluationLogic.js
+++ b/ctp-docente-portal.client/src/context/useEvaluationLogic.js
@@ -52,7 +52,7 @@ export const useEvaluationLogic = () => {
     const fetchAcademicPeriods = async () => {
       try {
         setLoading(true);
-        const token = localStorage.getItem("token");
+        const token = sessionStorage.getItem("token");
         const response = await axios.get("/api/academicperiods", {
           headers: { Authorization: `Bearer ${token}` },
         });
@@ -72,13 +72,14 @@ export const useEvaluationLogic = () => {
       try {
         setLoading(true);
         if (selectedPeriod) {
-          const token = localStorage.getItem("token");
+          const token = sessionStorage.getItem("token");
           const response = await axios.get(
             `/api/subject/period/${selectedPeriod}/subjects`,
             {
               headers: { Authorization: `Bearer ${token}` },
             }
           );
+
           setSubjects(response.data);
         }
       } catch (error) {
@@ -99,7 +100,7 @@ export const useEvaluationLogic = () => {
           // setSelectedGroup("");
           setStudents([]);
           setEvaluationItems([]);
-          const token = localStorage.getItem("token");
+          const token = sessionStorage.getItem("token");
           const response = await axios.get(
             `/api/section/period/${selectedPeriod}/subjects/${selectedSubject}/sections`,
             {
@@ -135,7 +136,7 @@ export const useEvaluationLogic = () => {
         if (selectedPeriod && selectedSubject && selectedGroup) {
           setStudents([]);
           setEvaluationItems([]);
-          const token = localStorage.getItem("token");
+          const token = sessionStorage.getItem("token");
           const response = await axios.get(
             `/api/evaluationscores/subject/${selectedSubject}/section/${selectedGroup}`,
             {

--- a/ctp-docente-portal.client/src/pages/Dashboard.jsx
+++ b/ctp-docente-portal.client/src/pages/Dashboard.jsx
@@ -15,7 +15,7 @@ const API_ENDPOINTS = {
 };
 
 const fetchTeacherStatistics = async () => {
-  const token = localStorage.getItem("token");
+  const token = sessionStorage.getItem("token");
   const { data } = await axios.get(API_ENDPOINTS.teacher(72, 2), {
     headers: { Authorization: `Bearer ${token}` },
   });
@@ -30,7 +30,7 @@ const fetchTeacherStatistics = async () => {
 };
 
 const fetchAdministrativeStatistics = async () => {
-  const token = localStorage.getItem("token");
+  const token = sessionStorage.getItem("token");
   const [summary, topSections, gradesDist] = await Promise.all([
     axios.get(API_ENDPOINTS.administrative, {
       headers: { Authorization: `Bearer ${token}` },

--- a/ctp-docente-portal.client/src/pages/EvaluationItemForm.jsx
+++ b/ctp-docente-portal.client/src/pages/EvaluationItemForm.jsx
@@ -39,12 +39,21 @@ const EvaluationItemForm = () => {
           ? `/api/evaluationcriteria/item/${itemId}`
           : null;
 
+        const token = sessionStorage.getItem("token");
         const [categoriesResponse, itemResponse, criteriaResponse] =
           await Promise.all([
-            axios.get(categoriesURL),
-            itemURL ? axios.get(itemURL) : Promise.resolve({ data: {} }),
+            axios.get(categoriesURL, {
+              headers: { Authorization: `Bearer ${token}` },
+            }),
+            itemURL
+              ? axios.get(itemURL, {
+                  headers: { Authorization: `Bearer ${token}` },
+                })
+              : Promise.resolve({ data: {} }),
             criteriaURL
-              ? axios.get(criteriaURL)
+              ? axios.get(criteriaURL, {
+                  headers: { Authorization: `Bearer ${token}` },
+                })
               : Promise.resolve({ data: [] }),
           ]);
 
@@ -78,7 +87,14 @@ const EvaluationItemForm = () => {
         SectionAssignmentId: parseInt(selectedGroup),
         CreatedBy: 1,
       };
-      const response = await axios.post("/api/evaluationitems/draft", itemData);
+      const token = sessionStorage.getItem("token");
+      const response = await axios.post(
+        "/api/evaluationitems/draft",
+        itemData,
+        {
+          headers: { Authorization: `Bearer ${token}` },
+        }
+      );
       console.log("Item creado en modo borrador");
       setCurrentItemId(response.data.evaluationItemId);
     } catch (error) {
@@ -92,7 +108,10 @@ const EvaluationItemForm = () => {
   const deleteItem = async () => {
     try {
       setLoading(true);
-      await axios.delete(`/api/evaluationitems/${currentItemId}`);
+      const token = sessionStorage.getItem("token");
+      await axios.delete(`/api/evaluationitems/${currentItemId}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
     } catch (error) {
       console.error(error?.response?.data?.Message);
     } finally {
@@ -261,9 +280,24 @@ const EvaluationItemForm = () => {
       if (currentItemId) {
         try {
           setLoading(true);
+          const token = sessionStorage.getItem("token");
+          const selectedSubject = sessionStorage.getItem("selectedSubject");
+          const selectedGroup = sessionStorage.getItem("selectedGroup");
+
+          const idAssingment = await axios.get(
+            `/api/SectionAssignments/getassignmentid?subjectId=${selectedSubject}&sectionId=${selectedGroup}`,
+            {
+              headers: { Authorization: `Bearer ${token}` },
+            }
+          );
+
+          itemData.SectionAssignmentId = idAssingment.data;
           const response = await axios.put(
             `/api/evaluationitems/${currentItemId}`,
-            itemData
+            itemData,
+            {
+              headers: { Authorization: `Bearer ${token}` },
+            }
           );
           console.log(response);
           setItem(false);
@@ -293,13 +327,29 @@ const EvaluationItemForm = () => {
       } else {
         try {
           setLoading(true);
-          const response = await axios.post("/api/evaluationitems/", itemData);
+          const token = sessionStorage.getItem("token");
+          const selectedSubject = sessionStorage.getItem("selectedSubject");
+          const selectedGroup = sessionStorage.getItem("selectedGroup");
+
+          const idAssingment = await axios.get(
+            `/api/SectionAssignments/getassignmentid?subjectId=${selectedSubject}&sectionId=${selectedGroup}`,
+            {
+              headers: { Authorization: `Bearer ${token}` },
+            }
+          );
+
+          itemData.SectionAssignmentId = idAssingment.data;
+
+          const response = await axios.post("/api/evaluationitems/", itemData, {
+            headers: { Authorization: `Bearer ${token}` },
+          });
           const { data } = response;
           data.evaluationCategoryName = item.evaluationCategoryName;
           const updatedEvaluationItems = [...evaluationItems, data];
           toast.success("Ítem creado exitosamente.");
           updateEvaluationItems(updatedEvaluationItems);
           setItem(false);
+          // window.location.reload();
           navigate("/calificaciones");
         } catch (error) {
           console.error(error?.response?.data?.Message);
@@ -326,8 +376,11 @@ const EvaluationItemForm = () => {
     if (criteria[index].id !== 0) {
       try {
         setLoading(true);
+        const token = sessionStorage.getItem("token");
         const id = criteria[index].id;
-        await axios.delete(`/api/evaluationcriteria/${id}`);
+        await axios.delete(`/api/evaluationcriteria/${id}`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
         toast.success("Criterio eliminado exitosamente.");
         setCriteria(criteria.filter((_, i) => i !== index));
       } catch (error) {

--- a/ctp-docente-portal.client/src/pages/GradeEvaluationItem.jsx
+++ b/ctp-docente-portal.client/src/pages/GradeEvaluationItem.jsx
@@ -39,7 +39,7 @@ const GradeEvaluationItem = () => {
     const fetchEvaluationData = async () => {
       try {
         setLoading(true);
-        const token = localStorage.getItem("token");
+        const token = sessionStorage.getItem("token");
         const URL = `/api/evaluationitems/item/${itemId}`;
 
         const response = await axios.get(URL, {
@@ -127,7 +127,7 @@ const GradeEvaluationItem = () => {
         updatedBy
       );
 
-      const token = localStorage.getItem("token");
+      const token = sessionStorage.getItem("token");
       const response = await axios.post(
         `/api/studentcriteriascores/section/${selectedGroup}`,
         payload,

--- a/ctp-docente-portal.client/src/services/api.js
+++ b/ctp-docente-portal.client/src/services/api.js
@@ -5,7 +5,7 @@ import axios from "axios";
 //const instance = axios.create({
 //    baseURL: "http://localhost:5103/api",
 //});
-const token = localStorage.getItem("token");
+const token = sessionStorage.getItem("token");
 
 const instance = axios.create({
   baseURL: import.meta.env.VITE_API_URL ?? "/api",

--- a/ctp-docente-portal.client/src/services/sectionsService.js
+++ b/ctp-docente-portal.client/src/services/sectionsService.js
@@ -3,7 +3,7 @@ import api from "./api";
 
 export const sectionsApi = {
   async active() {
-    const token = localStorage.getItem("token");
+    const token = sessionStorage.getItem("token");
     const { data } = await api.get("/section/active", {
       headers: { Authorization: `Bearer ${token}` },
     });


### PR DESCRIPTION
Backend endpoints and services for sections, evaluation items, scores, and students now require the authenticated user's ID for authorization and data filtering. Added SectionAssignment ID lookup endpoint. On the frontend, switched token storage from localStorage to sessionStorage and updated all API calls to use sessionStorage for tokens. Also removed the Estudiantes route and sidebar link, and improved authorization handling in evaluation item and grading components.